### PR TITLE
changed attribute name from nazwa to name in ShippingMethod

### DIFF
--- a/lib/openpayu/models/shipping_method.rb
+++ b/lib/openpayu/models/shipping_method.rb
@@ -2,8 +2,8 @@
 module OpenPayU
   module Models
     class ShippingMethod < Model
-      attr_accessor :country, :price, :nazwa
-      validates :country, :price, :nazwa, presence: true
+      attr_accessor :country, :price, :name
+      validates :country, :price, :name, presence: true
     end
   end
 end


### PR DESCRIPTION
This resolves the error:

{"OpenPayU":{"OrderCreateResponse":{"Status":{"StatusCode":"ERROR_VALUE_INVALID","StatusDesc":"The
content of element 'ShippingMethod' is not complete. One of
'{\"http://www.openpayu.com/20/openpayu.xsd\":Name}' is
expected.","Location":"OpenPayU.OrderCreateRequest.OrderCreateRequest$ShippingMethods.ShippingMethodType"},"ResId":"{f8773afd-4e2f-405b-a131-567d8895f430}"}}}.

That appears when creating the request object.
