### PR TITLE
Continue url rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or install it yourself as:
         config.env              = 'secure'
         config.order_url        = 'http://localhost/order'
         config.notify_url       = 'http://localhost/notify'
-        config.continue_url     = 'http://localhost/success'
+        config.complete_url     = 'http://localhost/success'
     end
 
   Or by providing a path to YAML file
@@ -48,7 +48,7 @@ Or install it yourself as:
       env: secure
       order_url: http://localhost/order
       notify_url: http://localhost/notify
-      continue_url: http://localhost/success
+      complete_url: http://localhost/success
     production:
       merchant_pos_id: '145227'
       signature_key: 13a980d4f851f3d9a1cfc792fb1f5e50
@@ -58,7 +58,7 @@ Or install it yourself as:
       env: secure
       order_url: http://localhost/order
       notify_url: http://localhost/notify
-      continue_url: http://localhost/success
+      complete_url: http://localhost/success
 
 ##Usage
 
@@ -75,7 +75,7 @@ Or install it yourself as:
       currency_code: "PLN",
       total_amount: 10000,
       notify_url: "http://localhost/",
-      continue_url: "http://localhost/",
+      complete_url: "http://localhost/",
       buyer: {
         email: 'dd@ddd.pl',
         phone: '123123123',

--- a/lib/openpayu/configuration.rb
+++ b/lib/openpayu/configuration.rb
@@ -10,7 +10,7 @@ module OpenPayU
     class << self
       attr_accessor :env, :merchant_pos_id, :pos_auth_key, :client_id,
         :client_secret, :signature_key, :service_domain, :country, :data_format,
-          :algorithm, :protocol, :order_url, :notify_url, :continue_url
+          :algorithm, :protocol, :order_url, :notify_url, :complete_url
 
       def configure(file_path = nil)
         set_defaults

--- a/lib/openpayu/models/order.rb
+++ b/lib/openpayu/models/order.rb
@@ -8,7 +8,7 @@ module OpenPayU
                     COMPLETED WAITING_FOR_CONFIRMATION)
       attr_accessor :customer_ip, :ext_order_id, :merchant_pos_id, :description,
         :currency_code, :total_amount, :validity_time, :notify_url, :order_url,
-          :continue_url, :req_id, :ref_req_id, :properties
+          :complete_url, :req_id, :ref_req_id, :properties
       validates :customer_ip, :ext_order_id, :merchant_pos_id, :description,
         :currency_code, :total_amount, presence: true
       has_one_object :buyer # not required
@@ -20,7 +20,7 @@ module OpenPayU
         @req_id       ||= "{#{SecureRandom.uuid}}"
         @notify_url   ||= OpenPayU::Configuration.notify_url
         @order_url    ||= OpenPayU::Configuration.order_url
-        @continue_url ||= OpenPayU::Configuration.continue_url
+        @complete_url ||= OpenPayU::Configuration.complete_url
       end
     end
   end

--- a/spec/openpayu.yml
+++ b/spec/openpayu.yml
@@ -8,4 +8,4 @@ test:
   env: secure
   order_url: http://localhost/order
   notify_url: http://localhost/notify
-  continue_url: http://localhost/success
+  complete_url: http://localhost/success

--- a/spec/test_objects/order.rb
+++ b/spec/test_objects/order.rb
@@ -12,7 +12,7 @@ module  TestObject
         currency_code: 'PLN',
         total_amount: 100,
         notify_url: 'http://localhost/',
-        continue_url: 'http://localhost/',
+        complete_url: 'http://localhost/',
         validity_time: '48000',
         buyer: {
           email: 'dd@ddd.pl',


### PR DESCRIPTION
According to the documentation, the parameter's name that holds success link is 'complete_url' not 'continue_url'. 
