### PR TITLE
Buyer invoice

### DIFF
--- a/lib/openpayu/models/buyer/invoice.rb
+++ b/lib/openpayu/models/buyer/invoice.rb
@@ -1,7 +1,7 @@
 # -*- encoding : utf-8 -*-
 module OpenPayU
   module Models
-    class Buyer::Delivery < Address
+    class Buyer::Invoice < Address
       attr_accessor :TIN, :e_invoice_requested
     end
   end

--- a/lib/openpayu/models/buyer/invoice.rb
+++ b/lib/openpayu/models/buyer/invoice.rb
@@ -2,7 +2,7 @@
 module OpenPayU
   module Models
     class Buyer::Invoice < Address
-      attr_accessor :TIN, :e_invoice_requested
+      attr_accessor :tin, :einvoice_requested
     end
   end
 end


### PR DESCRIPTION
Before fix following issues have occured:
### TIN parameters error

When using folowing paramter in Order.create (only part of whole parameter)

``` json
      {
        buyer: {
          tin: "888-111-11-22"
        }
      }
```

I get this error

``` ruby
undefined method `tin=' for #<OpenPayU::Models::Buyer::Invoice:0x007fcf744eae08>'
```

FIX: Rename paramter to lowercase. BTW. in DOC on http://developers.payu.com/ this parameter is uppercase, in HTTP request it goes lowercase and server accept it (see below, one of your server response)

> (13 known properties: \"postalBox\", \"street\", \"recipientEmail\", \"countryCode\", \"recipientName\", \"einvoiceRequested\", \"city\", \"name\", \"addressId\", \"state\", \"recipientPhone\", \"postalCode\", \"tin\"])
### e_invoice_requested paramater error on HTTP request

When using folowing paramter in Order.create (only part of whole parameter)

``` json
      {
        buyer: {
          e_invoice_requested: "TRUE"
        }
      }
```

I get following error:

``` json
{
    "resId": null,
    "status": {
        "statusCode": "ERROR_INTERNAL",
        "severity": "ERROR",
        "code": null,
        "codeLiteral": null,
        "location": null,
        "statusDesc": "Could not read JSON: Unrecognized field \"eInvoiceRequested\" (class com.openpayu.entity.v2_0.InvoiceType), not marked as ignorable (13 known properties: \"postalBox\", \"street\", \"recipientEmail\", \"countryCode\", \"recipientName\", \"einvoiceRequested\", \"city\", \"name\", \"addressId\", \"state\", \"recipientPhone\", \"postalCode\", \"tin\"])\n at [Source: pl.payu.checkout.filter.PayloadLoggingFilter$ResettableStreamHttpServletRequest$ResettableServletInputStream@6ee290ff; line: 1, column: 534] (through reference chain: com.openpayu.entity.pub.v2_0.OrderCreateRequest[\"buyer\"]->com.openpayu.entity.v2_0.CustomerOrderType[\"invoice\"]->com.openpayu.entity.v2_0.InvoiceType[\"eInvoiceRequested\"]); nested exception is com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field \"eInvoiceRequested\" (class com.openpayu.entity.v2_0.InvoiceType), not marked as ignorable (13 known properties: \"postalBox\", \"street\", \"recipientEmail\", \"countryCode\", \"recipientName\", \"einvoiceRequested\", \"city\", \"name\", \"addressId\", \"state\", \"recipientPhone\", \"postalCode\", \"tin\"])\n at [Source: pl.payu.checkout.filter.PayloadLoggingFilter$ResettableStreamHttpServletRequest$ResettableServletInputStream@6ee290ff; line: 1, column: 534] (through reference chain: com.openpayu.entity.pub.v2_0.OrderCreateRequest[\"buyer\"]->com.openpayu.entity.v2_0.CustomerOrderType[\"invoice\"]->com.openpayu.entity.v2_0.InvoiceType[\"eInvoiceRequested\"])"
    },
    "properties": null,
    "redirectUri": null,
    "version": "2.0",
    "orderId": null,
    "extOrderId": null,
    "payMethods": null
}
```

FIX: rename parameter. DOC says taht parameter's name in HTTP request should be `EInvoiceRequested` but your server accepts `einvoiceRequested` (see error above)

> (13 known properties: \"postalBox\", \"street\", \"recipientEmail\", \"countryCode\", \"recipientName\", \"einvoiceRequested\", \"city\", \"name\", \"addressId\", \"state\", \"recipientPhone\", \"postalCode\", \"tin\"])
