### PR TITLE
poprawione testy

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ VCR.configure do |c|
 end
 
 RSpec.configure do |config|
+  config.filter_run_excluding broken: true
   config.before(:all) do
     OpenPayU::Configuration.configure do |cfg|
       cfg.env              = 'secure'

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -8,12 +8,14 @@ describe OpenPayU::Configuration do
       ENV['RACK_ENV'] = 'test'
       OpenPayU::Configuration.configure 'spec/openpayu.yml'
     end
+    let(:config) { OpenPayU::Configuration }
 
-    it { OpenPayU::Configuration.valid?.should be_true }
-    it { OpenPayU::Configuration.merchant_pos_id.should eq '145227' }
-    it { OpenPayU::Configuration.env.should eq 'secure' }
-    it { OpenPayU::Configuration.service_domain.should eq 'payu.com' }
-
+    specify do
+      expect(config).to be_valid
+      expect(config.merchant_pos_id).to eq('145227')
+      expect(config.env).to eq('secure')
+      expect(config.service_domain).to eq('payu.com')
+    end
   end
 
   context 'valid configuration' do
@@ -24,17 +26,20 @@ describe OpenPayU::Configuration do
         config.service_domain   = 'payu.pl'
       end
     end
+    let(:config) { OpenPayU::Configuration }
 
-    it { OpenPayU::Configuration.valid?.should be_true }
-    it { OpenPayU::Configuration.env.should eq 'sandbox' }
-    it { OpenPayU::Configuration.service_domain.should eq 'payu.pl' }
+    specify do
+      expect(config).to be_valid
+      expect(config.env).to eq('sandbox')
+      expect(config.service_domain).to eq('payu.pl')
+    end
 
     it 'should override default' do
-      OpenPayU::Configuration.env.should eq 'sandbox'
+      expect(config.env).to eq('sandbox')
     end
 
     it 'should set default value' do
-      OpenPayU::Configuration.country.should eq 'pl'
+      expect(config.country).to eq('pl')
     end
 
     context 'change configuration to be invalid' do

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -5,14 +5,14 @@ describe OpenPayU::Document do
   let(:document) { OpenPayU::Document.new }
 
   it 'generates valid signature' do
-    document.generate_signature_structure(
+    expect(document.generate_signature_structure(
       'OpenPayUData',
       'SHA-1',
       'MerchantPosId',
       'SignatureKey'
-    ).should eq(
-      'sender=MerchantPosId;' +
-      'signature=52bb16149d1a5ccc8ac05f8e435c30d82efd5364;algorithm=SHA-1'
+    )).to( 
+      include('sender=MerchantPosId')
+      .and include('signature=52bb16149d1a5ccc8ac05f8e435c30d82efd5364;algorithm=SHA-1')
     )
   end
 end

--- a/spec/unit/models/order_spec.rb
+++ b/spec/unit/models/order_spec.rb
@@ -5,21 +5,23 @@ describe OpenPayU::Models::Order do
   context 'create valid order' do
     let(:order) { OpenPayU::Models::Order.new(TestObject::Order.valid_order) }
 
-    it { order.valid?.should be_true }
-    it { order.all_objects_valid?.should be_true }
-    it { order.merchant_pos_id.should eq OpenPayU::Configuration.merchant_pos_id }
+    specify do
+      expect(order).to be_valid
+      expect(order.all_objects_valid?).to eq(true)
+      expect(order.merchant_pos_id).to eq(OpenPayU::Configuration.merchant_pos_id)
+    end
 
     context 'should create product objects' do
       before { order.products = [{ name: 'Produkt 1' }] }
 
-      it { order.products.size.should eq 1 }
-      it do
-        order.products.first.class.name.should eq 'OpenPayU::Models::Product'
+      specify do
+        expect(order.products.size).to eq(1)
+        expect(order.products).to include(an_instance_of(OpenPayU::Models::Product))
       end
     end
 
     context 'prepare correct Hash' do
-      it do
+      specify do
         hash = order.prepare_keys
         hash.delete('ReqId')
         hash.has_key?('merchantPosId')
@@ -45,8 +47,11 @@ describe OpenPayU::Models::Order do
         }
       )
     end
-    it { order.valid?.should be_false }
-    it { order.all_objects_valid?.should be_false }
+
+    specify do
+      expect(order).not_to be_valid
+      expect(order.all_objects_valid?).not_to be(true)
+    end
   end
 
 end

--- a/spec/unit/models/refund_spec.rb
+++ b/spec/unit/models/refund_spec.rb
@@ -10,7 +10,9 @@ describe OpenPayU::Models::Refund do
         amount: 1000
       })
     end
-    it { refund.valid?.should be_true }
+    specify do
+      expect(refund).to be_valid
+    end
   end
 
   context 'create invalid refund' do
@@ -19,6 +21,8 @@ describe OpenPayU::Models::Refund do
         amount: 1000
       })
     end
-    it { refund.valid?.should be_false }
+    specify do
+      expect(refund).not_to be_valid
+    end
   end
 end

--- a/spec/unit/openpayu_spec.rb
+++ b/spec/unit/openpayu_spec.rb
@@ -7,18 +7,21 @@ describe OpenPayU do
       'TotalAmount' => '1000',
       'CompleteUrl' => 'http://localhost/complete'
     }
-    OpenPayU.sign_form(form).should eq(
-      'sender=114207;signature=e83176051ce82949552bb787c6c16385;algorithm=MD5'
-      )
+    expect(OpenPayU.sign_form(form)).to(
+      match('sender=114207')
+      .and match('signature=e83176051ce82949552bb787c6c16385;algorithm=MD5')
+    )
   end
 
   it 'should generate form' do
     order = TestObject::Order.valid_order
     form = OpenPayU.hosted_order_form(order).gsub(/>\s+</, '><')
-    form.should match(/<form method='post' action='.*'>/)
-    form.should match(/(<input type='hidden' name='.*' value='.*' \/>)+/)
-    form.should match(/(<button type='submit' formtarget='_blank' \/>){1}/)
-    form.should match(/<\/form>/)
+    expect(form).to(
+      match(/<form method='post' action='.*'>/)
+      .and match(/(<input type='hidden' name='.*' value='.*' \/>)+/)
+      .and match(/(<button type='submit' formtarget='_blank' \/>){1}/)
+      .and match(/<\/form>/)
+    )
   end
 
 end


### PR DESCRIPTION
powiązany ticket: #10 

A przy okazji:
- przepisane na składnię `expect(...).to(...)`
- testy zawierające pojedyncze asercje przerobione na bardziej idiomatyczną składnię
- zakomentowany blok z niedziałającym testem refund zastąpiony flagą i filtrem pomijającym
